### PR TITLE
Stylized the assistant selection page and navigation bar

### DIFF
--- a/EchoHub/ActionView.swift
+++ b/EchoHub/ActionView.swift
@@ -80,11 +80,11 @@ struct ActionView: View {
     var body: some View {
         Form {
             Section(header: Text("Name")) {
-                TextField("Name", text: $name);
+                TextField("Name (e.g. 'Turn on lights')", text: $name);
             }
             
             Section(header: Text("Prompt")) {
-                TextField("Prompt", text: $prompt, axis: .vertical)
+                TextField("Prompt (e.g. 'Alexa, turn on the lights')", text: $prompt, axis: .vertical)
             }
 
             if (image == nil) {

--- a/EchoHub/AlexaView.swift
+++ b/EchoHub/AlexaView.swift
@@ -16,9 +16,9 @@ struct AlexaView: View {
         NavigationStack {
             VStack(spacing: 0) {
                 NavigationBarView()
-                    .padding(.horizontal, 15)
-                    .padding(.bottom)
-                    .background(Color.white)
+                    .frame(width: 400)
+                    .padding(.bottom, 5)
+                    .background(primaryColor)
                 ScrollView(.vertical, showsIndicators: false, content: {
                     VStack(spacing: 0, content: {
                         CategoryView(

--- a/EchoHub/AssistantSelectView.swift
+++ b/EchoHub/AssistantSelectView.swift
@@ -12,19 +12,51 @@ import PhotosUI
 struct AssistantSelectView: View {
     var body: some View {
         NavigationStack {
-            VStack(spacing: 100) {
-                NavigationLink(destination: {
-                    AlexaView()
-                }, label: {
-                    Text("Amazon Alexa")
-                });
-                NavigationLink(destination: {
-                    ActionView(action: nil)
-                }, label: {
-                    Text("Add Action")
-                });
+            ZStack {
+                primaryColor.ignoresSafeArea()
+                VStack(spacing: 50) {
+                    Text("Welcome to EchoHub")
+                        .foregroundStyle(Color.white)
+                        .font(.system(size: 50))
+                        .fontWeight(/*@START_MENU_TOKEN@*/.bold/*@END_MENU_TOKEN@*/)
+                        .multilineTextAlignment(.center)
+                    Image(systemName: "homepodmini.2.fill")
+                        .resizable()
+                        .foregroundColor(.white)
+                        .frame(width: 115, height: 100)
+                    Spacer().frame(height: 0)
+                    Text("Please select your assistant:")
+                        .foregroundStyle(Color.white)
+                        .font(.system(size: 25))
+                        .fontWeight(.light)
+                    NavigationLink(destination: {
+                        AlexaView()
+                    }, label: {
+                        Text("Amazon Alexa")
+                            .foregroundStyle(Color.white)
+                            .font(.system(size: 30))
+                            .fontWeight(.semibold)
+                            .padding()
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 16)
+                                    .stroke(.white, lineWidth: 2)
+                            )
+                    });
+                    NavigationLink(destination: {
+                        // ActionView(action: nil)
+                    }, label: {
+                        Text("Google Home")
+                            .foregroundStyle(Color.white)
+                            .font(.system(size: 30))
+                            .fontWeight(.semibold)
+                            .padding()
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 16)
+                                    .stroke(.white, lineWidth: 2)
+                            )
+                    });
+                }
             }
-            .navigationTitle("Assistant Selection")
         }
     }
 }

--- a/EchoHub/Constant.swift
+++ b/EchoHub/Constant.swift
@@ -17,6 +17,7 @@ let infoChoresIcons: [ActionJson] = Bundle.main.decode("Data/info_chores.json")
 let routinesIcons: [ActionJson] = Bundle.main.decode("Data/routines.json")
 
 // LAYOUT
+let primaryColor = Color(red: 0, green: 90/255, blue: 168/255)
 let columnSpacing: CGFloat = 10
 let rowSpacing: CGFloat = 10
 var gridLayout: [GridItem] {

--- a/EchoHub/NavigationBarView.swift
+++ b/EchoHub/NavigationBarView.swift
@@ -12,20 +12,31 @@ struct NavigationBarView: View {
     var body: some View {
         HStack {
             Button(action: { presentationMode.wrappedValue.dismiss() }, label: {
-                Image(systemName: "arrow.left")
+                Image(systemName: "arrow.left").foregroundColor(.white)
             })
-            Spacer()
+            Spacer().frame(width: 70)
             Text("Echo")
                 .font(.title3)
-                .fontWeight(.black)
-                .foregroundColor(.blue)
-            Image(systemName: "homepodmini.2.fill").foregroundColor(.blue)
+                .fontWeight(.bold)
+                .foregroundColor(.white)
+            Image(systemName: "homepodmini.2.fill").foregroundColor(.white)
             Text("Hub")
                 .font(.title3)
-                .fontWeight(.black)
-                .foregroundColor(.blue)
-            Spacer()
+                .fontWeight(.bold)
+                .foregroundColor(.white)
+            Spacer().frame(width: 60)
+            NavigationStack {
+                NavigationLink(destination: {
+                    ActionView(action: nil)
+                }, label: {
+                    Text("+")
+                        .font(.system(size: 40))
+                        .fontWeight(.light)
+                        .foregroundStyle(.white)
+                })
+            }
         }
+        .background(primaryColor)
     }
 }
 


### PR DESCRIPTION
I added styling to the AssistantSelectView to look similar to our Figma mockup in the requirements artifact. I also edited the NavigationBar to incorporate our primary color and keep our visuals consistent. Lastly, in the ActionView, I edited the "Name" and "Prompt" textfields' default values to include an example.

Assistant selection view:
<img width="434" alt="image" src="https://github.com/gshekhawat0820/EchoHub/assets/82404453/6a8ad2a2-bb63-434e-af77-1d6590207c5c">

Updated navigation bar in AlexaView:
<img width="431" alt="image" src="https://github.com/gshekhawat0820/EchoHub/assets/82404453/cd2a2596-8af3-42f6-8dbc-ed1c66e40c6a">
