### PR TITLE
Add navigation on action form submit

### DIFF
--- a/EchoHub/ActionIconView.swift
+++ b/EchoHub/ActionIconView.swift
@@ -8,8 +8,9 @@
 import SwiftUI
 
 struct ActionIconView: View {
+    @State private var showingSheet = false;
     
-    let action: Action
+    let action: Action;
     var body: some View {
         VStack(alignment: .leading, spacing: 6, content: {
             ZStack {
@@ -29,11 +30,13 @@ struct ActionIconView: View {
                     }
                 )
             }
-            NavigationLink(action.name) {
-                ActionView(action: action)
+            Button(action.name) {
+                showingSheet.toggle();
             }
             .font(.title3)
             .fontWeight(.semibold)
-        })
+        }).sheet(isPresented: $showingSheet) {
+            ActionView(action: action)
+        }
     }
 }

--- a/EchoHub/ActionView.swift
+++ b/EchoHub/ActionView.swift
@@ -10,15 +10,16 @@ import SwiftData
 
 struct ActionView: View {
     @Environment(\.modelContext) private var modelContext;
+    @Environment(\.dismiss) private var dismiss;
     
-    let action: Action?
+    let action: Action?;
 
     @State private var showPicker = false;
     @State private var sourceType = UIImagePickerController.SourceType.camera;
     @State private var image: UIImage? = nil;
     
-    @State private var name = "";
-    @State private var prompt =  "";
+    @State private var name: String = "";
+    @State private var prompt: String =  "";
     @State private var category: String = "Household";
     @State private var device: String = "Amazon Alexa";
     @State private var hidden: Bool = false;
@@ -32,21 +33,21 @@ struct ActionView: View {
             self.action = nil;
             return;
         }
+
+        self.action = action;
         
-        self.name = action.name;
-        self.prompt = action.prompt;
-        self.category = action.category;
-        self.device = "Amazon Alexa";
-        self.hidden = false;
-        self.favorite = false;
+        _name = .init(initialValue: action.name);
+        _prompt = .init(initialValue: action.prompt);
+        _category = .init(initialValue: action.category);
+        _device = .init(initialValue: action.device);
+        _hidden = .init(initialValue: action.hidden);
+        _favorite = .init(initialValue: action.favorite);
         
         guard action.imageData != nil else {
-            self.action = action;
             return;
         }
 
-        self.image = UIImage(data: action.imageData!);
-        self.action = action;
+        _image = .init(initialValue: UIImage(data: action.imageData!));
     }
 
     func addAction() {
@@ -75,94 +76,94 @@ struct ActionView: View {
 
             modelContext.insert(action)
         }
+        
+        dismiss();
     }
 
     var body: some View {
-        Form {
-            Section(header: Text("Name")) {
-                TextField("Name", text: $name);
-            }
-            
-            Section(header: Text("Prompt")) {
-                TextField("Prompt", text: $prompt, axis: .vertical)
-            }
-
-            if (image == nil) {
-                EmptyView()
-            } else {
-                Image(uiImage: image!)
-                    .resizable()
-                    .aspectRatio(1.0, contentMode: .fill)
-                    .scaledToFit()
-                    .frame(width: 75, height: 75, alignment: .center)
-                    .clipShape(.buttonBorder)
-            }
-            
-            Menu("Set icon") {
-                Button(
-                    action: {
-                        self.sourceType = UIImagePickerController.SourceType.camera;
-                        self.showPicker.toggle();
-                    },
-                    label: {
-                        Label(
-                            "Camera",
-                            systemImage: "camera"
-                        )
+        NavigationView {
+            Form {
+                Section(header: Text("Name")) {
+                    TextField("Name", text: self.$name);
+                }
+                
+                Section(header: Text("Prompt")) {
+                    TextField("Prompt", text: self.$prompt, axis: .vertical)
+                }
+                
+                if (self.image == nil) {
+                    EmptyView()
+                } else {
+                    Image(uiImage: self.image!)
+                        .resizable()
+                        .aspectRatio(1.0, contentMode: .fill)
+                        .scaledToFit()
+                        .frame(width: 75, height: 75, alignment: .center)
+                        .clipShape(.buttonBorder)
+                }
+                
+                Menu("Set icon") {
+                    Button(
+                        action: {
+                            self.sourceType = UIImagePickerController.SourceType.camera;
+                            self.showPicker.toggle();
+                        },
+                        label: {
+                            Label(
+                                "Camera",
+                                systemImage: "camera"
+                            )
+                        }
+                    )
+                    Button(
+                        action: {
+                            self.sourceType = UIImagePickerController.SourceType.photoLibrary;
+                            self.showPicker.toggle();
+                        },
+                        label: {
+                            Label(
+                                "Photo library",
+                                systemImage: "photo.stack"
+                            )
+                        }
+                    )
+                }
+                .environment(\.menuOrder, .fixed)
+                
+                Picker("Category", selection: self.$category) {
+                    ForEach(categories, id: \.self) {
+                        Text($0)
                     }
-                )
-                Button(
-                    action: {
-                        self.sourceType = UIImagePickerController.SourceType.photoLibrary;
-                        self.showPicker.toggle();
-                    },
-                    label: {
-                        Label(
-                            "Photo library",
-                            systemImage: "photo.stack"
-                        )
+                }
+                
+                Picker("Device", selection: self.$device) {
+                    ForEach(devices, id: \.self) {
+                        Text($0)
                     }
-                )
-            }
-            .environment(\.menuOrder, .fixed)
-            
-            Picker("Category", selection: $category) {
-                ForEach(categories, id: \.self) {
-                    Text($0)
+                }
+                
+                Toggle(isOn: self.$hidden) {
+                    Text("Hide")
+                }
+                
+                Toggle(isOn: self.$favorite) {
+                    Text("Favorite")
+                }
+                
+                Section {
+                    Button(action: addAction) {
+                        Text(self.action == nil ? "Submit" : "Save")
+                    }.disabled(name.isEmpty || prompt.isEmpty || image == nil)
                 }
             }
-
-            Picker("Device", selection: $device) {
-                ForEach(devices, id: \.self) {
-                    Text($0)
-                }
-            }
-
-            Toggle(isOn: $hidden) {
-                Text("Hide")
-            }
-
-            Toggle(isOn: $favorite) {
-                Text("Favorite")
-            }
-            
-            Section {
-                Button(action: addAction) {
-                    Text("Submit")
-                }
-            }
+            .navigationTitle(self.action == nil ? "Add Action" : "Edit Action")
+            .fullScreenCover(isPresented: self.$showPicker, content: {
+                ImagePickerView(
+                    showPicker: self.$showPicker,
+                    image: self.$image,
+                    sourceType: self.$sourceType
+                );
+            })
         }
-        .navigationTitle(action == nil ? "Add Action" : "Edit Action")
-        .fullScreenCover(isPresented: self.$showPicker, content: {
-            ImagePickerView(
-                showPicker: self.$showPicker,
-                image: self.$image,
-                sourceType: self.$sourceType
-            );
-        })
     }
 }
-
-//#Preview {
-//    GoogleView()
-//}

--- a/EchoHub/AssistantSelectView.swift
+++ b/EchoHub/AssistantSelectView.swift
@@ -10,6 +10,8 @@ import SwiftData
 import PhotosUI
 
 struct AssistantSelectView: View {
+    @State private var showingSheet = false;
+    
     var body: some View {
         NavigationStack {
             VStack(spacing: 100) {
@@ -18,11 +20,11 @@ struct AssistantSelectView: View {
                 }, label: {
                     Text("Amazon Alexa")
                 });
-                NavigationLink(destination: {
+                Button("Add Action") {
+                    showingSheet.toggle()
+                }.sheet(isPresented: $showingSheet) {
                     ActionView(action: nil)
-                }, label: {
-                    Text("Add Action")
-                });
+                }
             }
             .navigationTitle("Assistant Selection")
         }


### PR DESCRIPTION
This PR changes the action form into a sheet, meaning someone can hide it by swiping down. I made this change primarily because it makes it much simpler to deal with navigation upon clicking the submit button. When someone clicks the submit button now, the action form sheet will disappear, indicating to the user that _something_ has happened.

We may want to further expand on this by showing some sort of toast element on the screen.