### PR TITLE
Administrative mode functionality

### DIFF
--- a/EchoHub.xcodeproj/project.pbxproj
+++ b/EchoHub.xcodeproj/project.pbxproj
@@ -8,6 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		120435592B7966290054CB12 /* ActionToSpeech.swift in Sources */ = {isa = PBXBuildFile; fileRef = 120435582B7966290054CB12 /* ActionToSpeech.swift */; };
+		2606906C2BA9D23F00F71F12 /* PasscodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2606906B2BA9D23F00F71F12 /* PasscodeView.swift */; };
+		2606906E2BA9D24800F71F12 /* NumberPadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2606906D2BA9D24800F71F12 /* NumberPadView.swift */; };
+		260690702BA9D25500F71F12 /* PasscodeIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2606906F2BA9D25500F71F12 /* PasscodeIndicatorView.swift */; };
+		260690722BACAD6300F71F12 /* SetPasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260690712BACAD6300F71F12 /* SetPasswordView.swift */; };
 		260B06112B728EA300BD06D6 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 260B06102B728EA300BD06D6 /* LaunchScreen.storyboard */; };
 		260B06132B74588700BD06D6 /* AlexaView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260B06122B74588700BD06D6 /* AlexaView.swift */; };
 		260B06152B745AD100BD06D6 /* NavigationBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260B06142B745AD100BD06D6 /* NavigationBarView.swift */; };
@@ -31,6 +35,10 @@
 
 /* Begin PBXFileReference section */
 		120435582B7966290054CB12 /* ActionToSpeech.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionToSpeech.swift; sourceTree = "<group>"; };
+		2606906B2BA9D23F00F71F12 /* PasscodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasscodeView.swift; sourceTree = "<group>"; };
+		2606906D2BA9D24800F71F12 /* NumberPadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberPadView.swift; sourceTree = "<group>"; };
+		2606906F2BA9D25500F71F12 /* PasscodeIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasscodeIndicatorView.swift; sourceTree = "<group>"; };
+		260690712BACAD6300F71F12 /* SetPasswordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetPasswordView.swift; sourceTree = "<group>"; };
 		260B060F2B728E0200BD06D6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		260B06102B728EA300BD06D6 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		260B06122B74588700BD06D6 /* AlexaView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlexaView.swift; sourceTree = "<group>"; };
@@ -89,15 +97,19 @@
 				26D741282B71798200F93014 /* AssistantSelectView.swift */,
 				260B06122B74588700BD06D6 /* AlexaView.swift */,
 				260B063D2B795DA200BD06D6 /* CategoryView.swift */,
+				260690712BACAD6300F71F12 /* SetPasswordView.swift */,
 				B26B8F482B744BC4000843B9 /* ActionView.swift */,
 				260B063B2B795DA200BD06D6 /* ActionIconView.swift */,
 				260B06142B745AD100BD06D6 /* NavigationBarView.swift */,
 				B26B8F4C2B745783000843B9 /* ImagePickerView.swift */,
+				2606906B2BA9D23F00F71F12 /* PasscodeView.swift */,
 				120435582B7966290054CB12 /* ActionToSpeech.swift */,
+				2606906D2BA9D24800F71F12 /* NumberPadView.swift */,
 				B26B8F4A2B7453CB000843B9 /* ImagePicker.swift */,
 				B2034E4C2B76808400DFF681 /* Action.swift */,
 				260B063C2B795DA200BD06D6 /* CodableBundleExtension.swift */,
 				260B06332B795DA100BD06D6 /* Constant.swift */,
+				2606906F2BA9D25500F71F12 /* PasscodeIndicatorView.swift */,
 				260B06392B795DA200BD06D6 /* ActionJson.swift */,
 				260B06102B728EA300BD06D6 /* LaunchScreen.storyboard */,
 				260B06342B795DA100BD06D6 /* Data */,
@@ -193,16 +205,20 @@
 			files = (
 				260B06132B74588700BD06D6 /* AlexaView.swift in Sources */,
 				26D741292B71798200F93014 /* AssistantSelectView.swift in Sources */,
+				260690702BA9D25500F71F12 /* PasscodeIndicatorView.swift in Sources */,
 				120435592B7966290054CB12 /* ActionToSpeech.swift in Sources */,
 				B26B8F4B2B7453CB000843B9 /* ImagePicker.swift in Sources */,
 				26D741272B71798200F93014 /* EchoHubApp.swift in Sources */,
 				B2034E4D2B76808400DFF681 /* Action.swift in Sources */,
 				260B06492B795DA200BD06D6 /* CategoryView.swift in Sources */,
+				2606906E2BA9D24800F71F12 /* NumberPadView.swift in Sources */,
 				260B06152B745AD100BD06D6 /* NavigationBarView.swift in Sources */,
+				260690722BACAD6300F71F12 /* SetPasswordView.swift in Sources */,
 				260B06452B795DA200BD06D6 /* ActionJson.swift in Sources */,
 				B26B8F4D2B745783000843B9 /* ImagePickerView.swift in Sources */,
 				260B063F2B795DA200BD06D6 /* Constant.swift in Sources */,
 				B26B8F492B744BC4000843B9 /* ActionView.swift in Sources */,
+				2606906C2BA9D23F00F71F12 /* PasscodeView.swift in Sources */,
 				260B06472B795DA200BD06D6 /* ActionIconView.swift in Sources */,
 				260B06482B795DA200BD06D6 /* CodableBundleExtension.swift in Sources */,
 			);
@@ -338,7 +354,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"EchoHub/Preview Content\"";
-				DEVELOPMENT_TEAM = BF6VFYGTA3;
+				DEVELOPMENT_TEAM = DQGTG9S9LU;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = EchoHub/Info.plist;
@@ -349,12 +365,13 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen.storyboard;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.eecs495.EchoHubApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.eecs495.EchoHub;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -370,7 +387,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"EchoHub/Preview Content\"";
-				DEVELOPMENT_TEAM = BF6VFYGTA3;
+				DEVELOPMENT_TEAM = DQGTG9S9LU;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = EchoHub/Info.plist;
@@ -381,12 +398,13 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen.storyboard;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.eecs495.EchoHubApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.eecs495.EchoHub;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/EchoHub/ActionIconView.swift
+++ b/EchoHub/ActionIconView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct ActionIconView: View {
     @State private var showingSheet = false;
-    
+    @Binding var isAdmin: Bool
     let action: Action;
     var body: some View {
         VStack(spacing: 6, content: {
@@ -30,11 +30,19 @@ struct ActionIconView: View {
                     }
                 )
             }
-            Button(action.name) {
-                showingSheet.toggle();
+            if isAdmin {
+                Button(action.name) {
+                    showingSheet.toggle();
+                }
+                .font(.title3)
+                .fontWeight(.semibold)
             }
-            .font(.title3)
-            .fontWeight(.semibold)
+            else {
+                Text("\(action.name)")
+                    .font(.title3)
+                    .fontWeight(.semibold)
+                    .multilineTextAlignment(.center)
+            }
         })
         .onChange(of: showingSheet) { }
         .sheet(isPresented: $showingSheet) {

--- a/EchoHub/ActionIconView.swift
+++ b/EchoHub/ActionIconView.swift
@@ -12,7 +12,7 @@ struct ActionIconView: View {
     
     let action: Action;
     var body: some View {
-        VStack(alignment: .leading, spacing: 6, content: {
+        VStack(spacing: 6, content: {
             ZStack {
                 Button(
                     action: {

--- a/EchoHub/ActionView.swift
+++ b/EchoHub/ActionView.swift
@@ -145,10 +145,10 @@ struct ActionView: View {
                     }
                 }
                 
-                Picker("Device", selection: self.$device) {
-                    ForEach(devices, id: \.self) {
-                        Text($0)
-                    }
+                HStack {
+                    Text("Device")
+                    Spacer()
+                    Text(self.device).foregroundStyle(.gray)
                 }
                 
                 Toggle(isOn: self.$hidden) {

--- a/EchoHub/AlexaView.swift
+++ b/EchoHub/AlexaView.swift
@@ -16,7 +16,7 @@ struct AlexaView: View {
         NavigationStack {
             VStack(spacing: 0) {
                 NavigationBarView()
-                    .frame(width: 400)
+                    .frame(width: UIScreen.main.bounds.width)
                     .padding(.bottom, 5)
                     .background(primaryColor)
                 ScrollView(.vertical, showsIndicators: false, content: {

--- a/EchoHub/AlexaView.swift
+++ b/EchoHub/AlexaView.swift
@@ -11,41 +11,46 @@ import SwiftData
 struct AlexaView: View {
     @Environment(\.modelContext) var context
     @Query let actions: [Action];
+    @State private var isAdmin = false
 
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
-                NavigationBarView()
+                NavigationBarView(isAdmin: $isAdmin)
                     .frame(width: UIScreen.main.bounds.width)
-                    .padding(.bottom, 5)
+                    .padding(.bottom, 15)
                     .background(primaryColor)
                 ScrollView(.vertical, showsIndicators: false, content: {
                     VStack(spacing: 0, content: {
                         CategoryView(
+                            title: "Favorites ⭐",
+                            actions: actions.filter({ $0.favorite == true }),
+                            isAdmin: $isAdmin)
+                        CategoryView(
                             title: "Household 🏠",
-                            actions: actions.filter({ $0.category == "Household" })
+                            actions: actions.filter({ $0.category == "Household" }),
+                            isAdmin: $isAdmin
                         )
                         CategoryView(
                             title: "Entertainment 🎥",
-                            actions: actions.filter({ $0.category == "Entertainment" })
+                            actions: actions.filter({ $0.category == "Entertainment" }),
+                            isAdmin: $isAdmin
                         )
                         CategoryView(
                             title: "Communication 📞",
-                            actions: actions.filter({ $0.category == "Communication" })
+                            actions: actions.filter({ $0.category == "Communication" }),
+                            isAdmin: $isAdmin
                         )
                         CategoryView(
                             title: "Routines ⏰",
-                            actions: actions.filter({ $0.category == "Routines" })
+                            actions: actions.filter({ $0.category == "Routines" }),
+                            isAdmin: $isAdmin
                         )
                         CategoryView(
                             title: "Information & Chores 📋",
-                            actions: actions.filter({ $0.category == "Information & Chores" })
+                            actions: actions.filter({ $0.category == "Information & Chores" }),
+                            isAdmin: $isAdmin
                         )
-                        Button(action: {
-                            deleteAllData()
-                        }, label: {
-                            Text("Reset SwiftData")
-                        })
                     })
                 })
             }

--- a/EchoHub/AssistantSelectView.swift
+++ b/EchoHub/AssistantSelectView.swift
@@ -9,7 +9,8 @@ import SwiftUI
 import SwiftData
 import PhotosUI
 
-struct AssistantSelectView: View {    
+struct AssistantSelectView: View {
+    @Binding var passwordExists: Bool
     var body: some View {
         NavigationStack {
             ZStack {
@@ -25,7 +26,7 @@ struct AssistantSelectView: View {
                         .foregroundColor(.white)
                         .frame(width: 115, height: 100)
                     Spacer().frame(height: 0)
-                    Text("Please select your assistant:")
+                    Text("Please select your assistant: ")
                         .foregroundStyle(Color.white)
                         .font(.system(size: 25))
                         .fontWeight(.light)
@@ -55,6 +56,13 @@ struct AssistantSelectView: View {
                                     .stroke(.white, lineWidth: 2)
                             )
                     });
+                    
+                    Button(action: {
+                        KeychainManager.deletePassword()
+                        passwordExists = false
+                    }, label: {
+                        Text("Reset Password").foregroundStyle(.white)
+                    })
                 }
             }
         }
@@ -67,5 +75,5 @@ struct AssistantSelectView: View {
 // Information & Chores: Set alarm/reminders, Check weather, Check calendar, Grocery list, Reorder purchased items
 
 #Preview {
-    AssistantSelectView()
+    AssistantSelectView(passwordExists: .constant(true))
 }

--- a/EchoHub/CategoryView.swift
+++ b/EchoHub/CategoryView.swift
@@ -11,6 +11,7 @@ struct CategoryView: View {
     
     var title: String
     var actions: [Action]
+    @Binding var isAdmin: Bool
     
     var body: some View {
         HStack {
@@ -25,7 +26,9 @@ struct CategoryView: View {
         .padding(.bottom, 10)
         LazyVGrid(columns: gridLayout, spacing: 15, content: {
             ForEach(actions) { action in
-                ActionIconView(action: action)
+                if (isAdmin || !action.hidden) {
+                    ActionIconView(isAdmin: $isAdmin, action: action)
+                }
             }
         })
         .padding(15)
@@ -33,7 +36,7 @@ struct CategoryView: View {
 }
 
 #Preview {
-    CategoryView(title: "Household", actions: [])
+    CategoryView(title: "Household", actions: [], isAdmin: .constant(false))
         .previewLayout(.sizeThatFits)
         
 }

--- a/EchoHub/NavigationBarView.swift
+++ b/EchoHub/NavigationBarView.swift
@@ -10,12 +10,14 @@ import SwiftUI
 struct NavigationBarView: View {
     @Environment(\.presentationMode) private var presentationMode: Binding<PresentationMode>;
     @State private var showingSheet = false;
+    @Binding var isAdmin: Bool
+    @State private var showPasscode = false;
     var body: some View {
         HStack {
             Button(action: { presentationMode.wrappedValue.dismiss() }, label: {
-                Image(systemName: "arrow.left").foregroundColor(.white)
+                Image(systemName: "arrow.left").foregroundColor(.white).font(.system(size:20))
             })
-            Spacer().frame(width: 70)
+            Spacer().frame(width: 90)
             Text("Echo")
                 .font(.title3)
                 .fontWeight(.bold)
@@ -25,25 +27,42 @@ struct NavigationBarView: View {
                 .font(.title3)
                 .fontWeight(.bold)
                 .foregroundColor(.white)
-            Spacer().frame(width: 60)
+            Spacer().frame(width: 50)
             Button {
-                showingSheet.toggle();
+                if isAdmin {
+                    isAdmin = false
+                }
+                else {
+                    showPasscode.toggle()
+                }
             } label: {
-                Text("+")
-                    .font(.system(size: 40))
-                    .fontWeight(.light)
-                    .foregroundStyle(.white)
+                Image(systemName: !isAdmin ? "lock" : "lock.open")
+                    .foregroundColor(.white).font(.system(size: 20))
+            }
+            Spacer().frame(width: 20)
+            
+            if isAdmin {
+                Button {
+                    showingSheet.toggle();
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 20))
+                        .foregroundStyle(.white)
+                }
             }
         }
         .background(primaryColor)
         .sheet(isPresented: $showingSheet) {
             ActionView(action: nil)
         }
+        .sheet(isPresented: $showPasscode) {
+            PasscodeView(isAdmin: $isAdmin)
+        }
     }
 }
 
 #Preview {
-    NavigationBarView()
+    NavigationBarView(isAdmin: .constant(false))
         .previewLayout(.sizeThatFits)
         .padding()
 }

--- a/EchoHub/NumberPadView.swift
+++ b/EchoHub/NumberPadView.swift
@@ -1,0 +1,67 @@
+//
+//  NumberPadView.swift
+//  EchoHub
+//
+//  Created by Gaurav Shekhawat on 3/19/24.
+//
+
+import SwiftUI
+
+struct NumberPadView: View {
+    @Binding var passcode: String
+    private let columns: [GridItem] = [
+        .init(),
+        .init(),
+        .init()
+    ]
+    var body: some View {
+        LazyVGrid(columns: columns) {
+            ForEach(1 ... 9, id: \.self) { index in
+                Button {
+                    addValue(index)
+                } label: {
+                    Text("\(index)")
+                        .font(.title)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
+                        .contentShape(.rect)
+                }
+            }
+            Button {
+                removeValue()
+            } label: {
+                Image(systemName: "delete.backward")
+                    .font(.title)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+                    .contentShape(.rect)
+            }
+            Button {
+                addValue(0)
+            } label: {
+                Text("0")
+                    .font(.title)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+                    .contentShape(.rect)
+            }
+        }
+        .foregroundStyle(.white)
+    }
+    
+    private func addValue(_ value: Int) {
+        if passcode.count < 4 {
+            passcode += "\(value)"
+        }
+    }
+    
+    private func removeValue() {
+        if !passcode.isEmpty {
+            passcode.removeLast()
+        }
+    }
+}
+
+#Preview {
+    NumberPadView(passcode: .constant(""))
+}

--- a/EchoHub/PasscodeIndicatorView.swift
+++ b/EchoHub/PasscodeIndicatorView.swift
@@ -1,0 +1,29 @@
+//
+//  PasscodeIndicatorView.swift
+//  EchoHub
+//
+//  Created by Gaurav Shekhawat on 3/19/24.
+//
+
+import SwiftUI
+
+struct PasscodeIndicatorView: View {
+    @Binding var passcode: String
+    var body: some View {
+        HStack(spacing: 32) {
+            ForEach(0 ..< 4) { index in
+                Circle()
+                    .fill(passcode.count > index ? .white : primaryColor)
+                    .frame(width: 20, height: 20)
+                    .overlay {
+                        Circle()
+                            .stroke(.white, lineWidth: 1.0)
+                    }
+            }
+        }
+    }
+}
+
+#Preview {
+    PasscodeIndicatorView(passcode: .constant(""))
+}

--- a/EchoHub/PasscodeView.swift
+++ b/EchoHub/PasscodeView.swift
@@ -1,0 +1,88 @@
+//
+//  PasscodeView.swift
+//  EchoHub
+//
+//  Created by Gaurav Shekhawat on 3/19/24.
+//
+
+import SwiftUI
+
+struct PasscodeView: View {
+    @State private var passcode = ""
+    @Binding var isAdmin: Bool
+    @State private var showPassCodeError = false;
+    @State private var shake = false;
+    @Environment(\.dismiss) private var dismiss;
+    
+    var body: some View {
+        VStack(spacing: 48) {
+            VStack(spacing: 24) {
+                Text("Enter Passcode")
+                    .font(.largeTitle)
+                    .fontWeight(.heavy)
+                    .foregroundStyle(.white)
+                Text("Please enter your 4-digit pin to access administrative mode.")
+                    .font(.subheadline)
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.white)
+            }
+            .padding(.top, 90)
+            
+            // indicator view
+            
+            PasscodeIndicatorView(passcode: $passcode)
+            
+            if showPassCodeError {
+                Text("Incorrect password. Please try again.")
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(.red)
+                    .modifier(ShakeEffect(animatableData: shake ? 1 : 0))
+                    .animation(.linear, value: shake)
+            }
+            
+            Spacer()
+            
+            // numberpad view
+            
+            NumberPadView(passcode: $passcode)
+                .padding(.bottom, 30)
+        }
+        .background(primaryColor)
+        .onChange(of: passcode, { oldValue, newValue in 
+            verifyPasscode()
+        })
+    }
+    
+    private func verifyPasscode() {
+        guard passcode.count == 4 else { return }
+        
+        Task {
+            try? await Task.sleep(nanoseconds: 125_000_000)
+            isAdmin = passcode == KeychainManager.getPassword()
+            showPassCodeError = !isAdmin
+            passcode = ""
+            if isAdmin {
+                dismiss()
+            }
+            shake.toggle()
+        }
+    }
+}
+
+struct ShakeEffect: GeometryEffect {
+    var animatableData: CGFloat
+    
+    func modifier(_ x: CGFloat) -> CGFloat {
+        10 * sin(x * .pi * 2)
+    }
+    
+    func effectValue(size: CGSize) -> ProjectionTransform {
+        let transform = ProjectionTransform(CGAffineTransform(translationX: 10 + modifier(animatableData), y: 0))
+        
+        return transform
+    }
+}
+
+#Preview {
+    PasscodeView(isAdmin: .constant(false))
+}

--- a/EchoHub/SetPasswordView.swift
+++ b/EchoHub/SetPasswordView.swift
@@ -1,0 +1,61 @@
+//
+//  SetPasswordView.swift
+//  EchoHub
+//
+//  Created by Gaurav Shekhawat on 3/21/24.
+//
+
+import SwiftUI
+
+struct SetPasswordView: View {
+    @State private var passcode = ""
+    @Binding var passwordExists: Bool
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                primaryColor.ignoresSafeArea()
+                VStack(spacing: 48) {
+                    Text("Welcome to EchoHub")
+                        .foregroundStyle(Color.white)
+                        .font(.system(size: 40))
+                        .fontWeight(/*@START_MENU_TOKEN@*/.bold/*@END_MENU_TOKEN@*/)
+                        .multilineTextAlignment(.center)
+                    Image(systemName: "homepodmini.2.fill")
+                        .resizable()
+                        .foregroundColor(.white)
+                        .frame(width: 115, height: 100)
+                    Text("Please select a password: ")
+                        .foregroundStyle(Color.white)
+                        .font(.system(size: 25))
+                        .fontWeight(.light)
+                    
+                    PasscodeIndicatorView(passcode: $passcode)
+                    
+                    // numberpad view
+                    
+                    NumberPadView(passcode: $passcode)
+                        .padding(.bottom, 30)
+                }
+                .background(primaryColor)
+                .onChange(of: passcode, { oldValue, newValue in
+                    verifySetPassword()
+                })
+            }
+        }
+    }
+    
+    private func verifySetPassword() {
+        guard passcode.count == 4 else { return }
+        
+        Task {
+            try? await Task.sleep(nanoseconds: 125_000_000)
+            KeychainManager.savePassword(password: passcode)
+            passcode = ""
+            passwordExists = true
+        }
+    }
+}
+
+#Preview {
+    SetPasswordView(passwordExists: .constant(false))
+}


### PR DESCRIPTION
Created functionality for admin mode within the app. Includes password protection, hiding actions, and the ability to favorite actions. Passwords are securely stored in the Apple Keychain. 

Users can now only add, edit, and delete actions when they are in admin mode. When not in admin mode, hidden actions will not appear, but they will appear when in admin mode.

Upon launching the app for the first time, the user is prompted to set a password, which will be remembered. Moving forward, if the user wants to access admin mode, they must enter their password every time. If they are in admin mode and decide to go to the assistant selection page and back to the Alexa View, they will no longer be in admin mode and must reauthenticate. There is temporarily a button on the assistant selection page to reset the password without any verification, but we should implement a more secure method of resetting, such as entering your original password before setting a new one.