### PR TITLE
Edit actions by long pressing the icon

### DIFF
--- a/EchoHub.xcodeproj/project.pbxproj
+++ b/EchoHub.xcodeproj/project.pbxproj
@@ -431,7 +431,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"EchoHub/Preview Content\"";
-				DEVELOPMENT_TEAM = BF6VFYGTA3;
+				DEVELOPMENT_TEAM = DQGTG9S9LU;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = EchoHub/Info.plist;
@@ -448,7 +448,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.eecs495.EchoHubMobile;
+				PRODUCT_BUNDLE_IDENTIFIER = com.eecs495.EchoHubApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -465,7 +465,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"EchoHub/Preview Content\"";
-				DEVELOPMENT_TEAM = BF6VFYGTA3;
+				DEVELOPMENT_TEAM = DQGTG9S9LU;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = EchoHub/Info.plist;
@@ -482,7 +482,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.eecs495.EchoHubMobile;
+				PRODUCT_BUNDLE_IDENTIFIER = com.eecs495.EchoHubApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/EchoHub/ActionIconView.swift
+++ b/EchoHub/ActionIconView.swift
@@ -20,30 +20,52 @@ struct ActionIconView: View {
                         speaker.speak(action: action.prompt)
                     },
                     label: {
-                        Image(uiImage: UIImage(data: action.imageData!)!)
-                            .resizable()
-                            .frame(width: 90, height: 90)
-                            .clipShape(RoundedRectangle(cornerRadius: 20))
-                              .overlay {
-                                RoundedRectangle(cornerRadius: 20)
-                                  .stroke(.black, lineWidth: 3)
-                            }
+                        if isAdmin {
+                            Image(uiImage: UIImage(data: action.imageData!)!)
+                                .resizable()
+                                .frame(width: 90, height: 90)
+                                .clipShape(RoundedRectangle(cornerRadius: 20))
+                                  .overlay {
+                                    RoundedRectangle(cornerRadius: 20)
+                                      .stroke(.black, lineWidth: 3)
+                                }
+                                .contextMenu {
+                                    Button {
+                                        showingSheet.toggle();
+                                    } label: {
+                                        Label("Edit", systemImage: "pencil")
+                                    }
+                                }
+                        }
+                        else {
+                            Image(uiImage: UIImage(data: action.imageData!)!)
+                                .resizable()
+                                .frame(width: 90, height: 90)
+                                .clipShape(RoundedRectangle(cornerRadius: 20))
+                                  .overlay {
+                                    RoundedRectangle(cornerRadius: 20)
+                                      .stroke(.black, lineWidth: 3)
+                                }
+                        }
                     }
                 )
             }
-            if isAdmin {
-                Button(action.name) {
-                    showingSheet.toggle();
-                }
+//            if isAdmin {
+//                Text("\(action.name)")
+//                    .font(.title3)
+//                    .fontWeight(.semibold)
+//                    .multilineTextAlignment(.center)
+//            }
+//            else {
+//                Text("\(action.name)")
+//                    .font(.title3)
+//                    .fontWeight(.semibold)
+//                    .multilineTextAlignment(.center)
+//            }
+            Text("\(action.name)")
                 .font(.title3)
                 .fontWeight(.semibold)
-            }
-            else {
-                Text("\(action.name)")
-                    .font(.title3)
-                    .fontWeight(.semibold)
-                    .multilineTextAlignment(.center)
-            }
+                .multilineTextAlignment(.center)
         })
         .onChange(of: showingSheet) { }
         .sheet(isPresented: $showingSheet) {


### PR DESCRIPTION
Users can now edit actions in admin mode by long pressing any action icon. There is a slight visual bug concerning the borders when the icon is selected and the context menu is showing but it does not affect visibility of the image itself. In the future, we would also like to move the functionality for deleting an action into this context menu as well but that can be done in another ticket. Another item to note is that we left the add action button as a plus sign in the top right corner of the navigation bar. Below is an example of how the UI looks now:

![IMG_B8F90E5231E3-1](https://github.com/gshekhawat0820/EchoHub/assets/82404453/db800897-db97-4014-98a9-ac0ccf63a2be)
