### PR TITLE
Move save and cancel to top of action form

### DIFF
--- a/EchoHub/ActionView.swift
+++ b/EchoHub/ActionView.swift
@@ -162,10 +162,6 @@ struct ActionView: View {
                 }
                 
                 Section {
-//                    Button(action: addAction) {
-//                        Text(self.action == nil ? "Submit" : "Save")
-//                    }.disabled(name.isEmpty || prompt.isEmpty || image == nil)
-                    
                     if self.action == nil {
                         EmptyView();
                     } else {

--- a/EchoHub/ActionView.swift
+++ b/EchoHub/ActionView.swift
@@ -162,9 +162,9 @@ struct ActionView: View {
                 }
                 
                 Section {
-                    Button(action: addAction) {
-                        Text(self.action == nil ? "Submit" : "Save")
-                    }.disabled(name.isEmpty || prompt.isEmpty || image == nil)
+//                    Button(action: addAction) {
+//                        Text(self.action == nil ? "Submit" : "Save")
+//                    }.disabled(name.isEmpty || prompt.isEmpty || image == nil)
                     
                     if self.action == nil {
                         EmptyView();
@@ -196,6 +196,19 @@ struct ActionView: View {
                     sourceType: self.$sourceType
                 );
             })
+            .interactiveDismissDisabled()
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss();
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(self.action == nil ? "Submit" : "Save") {
+                        self.addAction();
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Prevents swiping away the action form. It was difficult to find out how to save on a swipe gesture.

Moves save and cancel buttons to the top of the form for easier access.

| Add    | Edit |
| -------- | ------- |
| ![IMG_6A6C6985F995-1](https://github.com/gshekhawat0820/EchoHub/assets/44459660/53eae311-d255-4da9-957c-9f28cc1095e7)  | ![image](https://github.com/gshekhawat0820/EchoHub/assets/44459660/6c1fcb68-cc0e-42e7-8ff3-8fd86a6079f5)  |